### PR TITLE
Active span for onError and onComplete callbacks

### DIFF
--- a/src/main/java/io/opentracing/contrib/reactor/TracedSubscriber.java
+++ b/src/main/java/io/opentracing/contrib/reactor/TracedSubscriber.java
@@ -76,12 +76,12 @@ public class TracedSubscriber<T> implements SpanSubscription<T> {
 
 	@Override
 	public void onError(Throwable throwable) {
-		subscriber.onError(throwable);
+		withActiveSpan(() -> subscriber.onError(throwable));
 	}
 
 	@Override
 	public void onComplete() {
-		subscriber.onComplete();
+		withActiveSpan(() -> subscriber.onComplete());
 	}
 
 	@Override


### PR DESCRIPTION
This PR wraps the subscriber's onError and onComplete callbacks with the active span. #9 

Co-Authored-By: Chengchen JI <cji@edgelab.ch>